### PR TITLE
Bugfix/session

### DIFF
--- a/projects/precise/src/app/core/http/tagger.service.ts
+++ b/projects/precise/src/app/core/http/tagger.service.ts
@@ -27,6 +27,7 @@ import { catchError } from 'rxjs/operators';
 
 export interface FileTag {
     audioFileId: string;
+    sessionId: string;
     tagId: string;
     tagValueId: string;
 }

--- a/projects/precise/src/app/modules/tagger/pages/tag/tag.component.html
+++ b/projects/precise/src/app/modules/tagger/pages/tag/tag.component.html
@@ -28,7 +28,7 @@
             </button>
         </div>
     </mat-card-content>
-    <mat-card-actions fxLayoutGap="12px">
+    <mat-card-actions fxLayoutGap="12px" fxLayoutAlign="center">
         <button
             mat-flat-button
             color="primary"

--- a/projects/precise/src/app/modules/tagger/pages/tag/tag.component.ts
+++ b/projects/precise/src/app/modules/tagger/pages/tag/tag.component.ts
@@ -34,7 +34,6 @@ export class TagComponent implements OnInit {
     public isTagged = false;
     public playIcon = faPlay;
     public pauseIcon = faPause;
-    public sessionId: string;
     public tagEvent: TagEvent;
     public preciseUrl = environment.mycroftUrls.precise;
     public wakeWord: string;
@@ -66,15 +65,13 @@ export class TagComponent implements OnInit {
     saveTagResult(tagValueId: string): void {
         const fileTag: FileTag = {
             audioFileId: this.tagEvent.audioFileId,
+            sessionId: this.tagEvent.sessionId,
             tagId: this.tagEvent.tagId,
             tagValueId: tagValueId
         };
         this.buttonsDisabled = true;
         this.taggerService.addTagEvent(fileTag).subscribe(
-            (session) => {
-                this.sessionId = session.sessionId;
-                this.isTagged = true;
-            }
+            () => { this.isTagged = true; }
         );
     }
 
@@ -85,7 +82,7 @@ export class TagComponent implements OnInit {
     }
 
     getNextTaggableFile(): void {
-        this.taggerService.getTagEvent(this.wakeWord, this.sessionId).subscribe(
+        this.taggerService.getTagEvent(this.wakeWord, this.tagEvent.sessionId).subscribe(
             (tagEvent: TagEvent) => {
                 this.isTagged = false;
                 this.tagEvent = tagEvent;

--- a/projects/precise/src/app/shared/models/tag-event.model.ts
+++ b/projects/precise/src/app/shared/models/tag-event.model.ts
@@ -25,6 +25,7 @@ export interface TagValue {
 export interface TagEvent {
     audioFileId: string;
     audioFileName: string;
+    sessionId: string;
     tagId: string;
     tagName: string;
     tagTitle: string;


### PR DESCRIPTION
## Description
In the tagging UI, moved the generation/retrieval of the session id earlier in the workflow to ensure it is available for the first tagging event.

## How to test
Session ID should be returned on the first request for a file to tag
