### PR TITLE
encode the SSH key passed to the API to handle special characters

### DIFF
--- a/projects/account/src/app/core/http/device.service.ts
+++ b/projects/account/src/app/core/http/device.service.ts
@@ -92,7 +92,7 @@ export class DeviceService {
     }
 
     validateSshKey(sshKey: string): Observable<any> {
-        return this.http.get<Observable<any>>(sshKeyUrl, {params: {key: encodeURIComponent(sshKey)}});
+        return this.http.get<Observable<any>>(sshKeyUrl + '/' + sshKey);
     }
 
     getGeographies() {

--- a/projects/account/src/app/core/http/device.service.ts
+++ b/projects/account/src/app/core/http/device.service.ts
@@ -92,7 +92,7 @@ export class DeviceService {
     }
 
     validateSshKey(sshKey: string): Observable<any> {
-        return this.http.get<Observable<any>>(sshKeyUrl + '/' + sshKey);
+        return this.http.get<Observable<any>>(sshKeyUrl, {params: {key: encodeURIComponent(sshKey)}});
     }
 
     getGeographies() {


### PR DESCRIPTION
## Description
Fixes an issue where the device edit screen will not allow saving because the SSH key endpoint would return a 500 error due to the special characters it contained.

## How to test
Enter a valid RSA SSH key into the device edit field of a Mark II device, the save button should be active.
