### PR TITLE
remove google tts as an option for devices

### DIFF
--- a/projects/account/src/app/modules/device/components/card/voice-card/voice-card.component.ts
+++ b/projects/account/src/app/modules/device/components/card/voice-card/voice-card.component.ts
@@ -31,7 +31,7 @@ export class VoiceCardComponent implements OnInit {
 
     constructor() {
         this.voiceOptionsConfig = {
-            options: ['British Male', 'American Male', 'Google Voice'],
+            options: ['British Male', 'American Male'],
             buttonWidth: '140px'
         };
     }


### PR DESCRIPTION
## Description
Remove the Google Voice as a TTS option from the device add and edit pages.

## How to test
Google TTS should no longer be an allowed option.
