### PR TITLE
Remove IP address from Mark II device information

### DIFF
--- a/projects/account/src/app/modules/device/components/card/device-display/device-display.component.html
+++ b/projects/account/src/app/modules/device/components/card/device-display/device-display.component.html
@@ -26,11 +26,13 @@
                     [value]="device.coreVersion"
             >
             </account-display-field>
-            <account-display-field *ngIf="device.pantacorConfig.pantacorId"
-                    [label]="'IP Address'"
-                    [value]="device.pantacorConfig.ipAddress"
-            >
-            </account-display-field>
+<!-- This is temporarily commented out because the IP address can change and not get -->
+<!-- properly communicated to Selene.  Add back to display when this is fixed. -->
+<!--            <account-display-field *ngIf="device.pantacorConfig.pantacorId"-->
+<!--                    [label]="'IP Address'"-->
+<!--                    [value]="device.pantacorConfig.ipAddress"-->
+<!--            >-->
+<!--            </account-display-field>-->
             <button
                 mat-flat-button
                 *ngIf="device.pantacorConfig.autoUpdate === false" (click)="applySoftwareUpdate()"


### PR DESCRIPTION
## Description
Remove the IP address field from the device temporarily until it can be tracked when it changes.

