### PR TITLE
Remove the wake word and voice options 

### DIFF
--- a/projects/account/src/app/modules/device/components/card/defaults-card/defaults-card.component.html
+++ b/projects/account/src/app/modules/device/components/card/defaults-card/defaults-card.component.html
@@ -9,8 +9,10 @@
                 [required]="true"
         >
         </account-geography-card>
-        <account-voice-card [voiceForm]="defaultsForm"></account-voice-card>
-        <account-wake-word-card [wakeWordForm]="defaultsForm">x</account-wake-word-card>
+<!-- Temporarily commented out for MVP.  Only available wake word is "Hey Mycroft".  -->
+<!--  Only available voice is the Mimic 3 British Male voice. -->
+<!--        <account-voice-card [voiceForm]="defaultsForm"></account-voice-card>-->
+<!--        <account-wake-word-card [wakeWordForm]="defaultsForm">x</account-wake-word-card>-->
     </mat-card-content>
     <mat-card-actions *ngIf="!addingDevice" align="right">
         <button mat-button (click)="onSave()" [disabled]="!defaultsForm.valid">SAVE</button>

--- a/projects/account/src/app/modules/device/components/card/device-edit-card/device-edit-card.component.html
+++ b/projects/account/src/app/modules/device/components/card/device-edit-card/device-edit-card.component.html
@@ -38,8 +38,10 @@
         </mat-card>
 
         <account-geography-card [geoForm]="deviceForm" [required]="true"></account-geography-card>
-        <account-voice-card [voiceForm]="deviceForm"></account-voice-card>
-        <account-wake-word-card [wakeWordForm]="deviceForm"></account-wake-word-card>
+<!-- Temporarily commented out for MVP.  Only available wake word is "Hey Mycroft".  -->
+<!--  Only available voice is the Mimic 3 British Male voice. -->
+<!--        <account-voice-card [voiceForm]="deviceForm"></account-voice-card>-->
+<!--        <account-wake-word-card [wakeWordForm]="deviceForm"></account-wake-word-card>-->
         <account-software-release-card
             *ngIf="pantacorId"
             [softwareReleaseForm]="deviceForm"


### PR DESCRIPTION
## Description
Remove the wake word and voice options from the device edit and default pages as a temporary measure for MVP

## How to test
Options are not accessible via the UI
