### PR TITLE
propagate default values when adding first device

### DIFF
--- a/projects/account/src/app/modules/device/pages/add/add.component.ts
+++ b/projects/account/src/app/modules/device/pages/add/add.component.ts
@@ -155,6 +155,16 @@ export class AddComponent implements OnInit {
 
     onDefaultsSubmit() {
         this.deviceService.addAccountDefaults(this.defaultsForm).subscribe();
+        this.deviceForm.patchValue(
+            {
+                city: this.defaultsForm.controls['city'].value,
+                country: this.defaultsForm.controls['country'].value,
+                region: this.defaultsForm.controls['region'].value,
+                timezone: this.defaultsForm.controls['timezone'].value,
+                wakeWord: this.defaultsForm.controls['wakeWord'].value,
+                voice: this.defaultsForm.controls['voice'].value
+            }
+        );
     }
 
     onFinished() {


### PR DESCRIPTION
## Description
when adding first device, if user sets any of the default values, ensure those are propagated to the pairing step.
## How to test
(Description of how to validate or test this PR)
